### PR TITLE
adding particle fix

### DIFF
--- a/src/main/java/com/direwolf20/mininggadgets/client/particles/laserparticle/LaserParticle.java
+++ b/src/main/java/com/direwolf20/mininggadgets/client/particles/laserparticle/LaserParticle.java
@@ -11,6 +11,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.BreakingItemParticle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -80,10 +81,14 @@ public class LaserParticle extends BreakingItemParticle {
         xo = x;
         yo = y;
         zo = z;
-        RenderBlockTileEntity te = (RenderBlockTileEntity) world.getBlockEntity(new BlockPos((int)this.x, (int)this.y, (int)this.z));
+        BlockEntity te = world.getBlockEntity(new BlockPos((int)this.x, (int)this.y, (int)this.z));
         if (te != null) {
-            playerUUID = te.getPlayerUUID();
-            voiding = !te.getBlockAllowed();
+            CompoundTag tag = te.getUpdateTag();
+
+            if (tag.contains("playerUUID")) {
+                playerUUID = tag.getUUID("playerUUID");
+            }
+            voiding = !tag.getBoolean("blockAllowed");
         }
         sourceX = d;
         sourceY = d1;


### PR DESCRIPTION
Following the issue #216 I managed to partially fix this particular bug.

The only side effect of this commit is that the problematic blocks are just ignored and not destroyed. But at the very least it doesn't make you crash.

**This will need further review to be able to completely work as intended.**

So what was the problem?
The problem occured when casting **RenderBlockTileEntity** class from a **BlockEntity** class using `world.getBlockEntity()`
I did not completely understood the whole picture and I couldn't retrieve the playerUUID and blockAllowed from **RenderBlockTileEntity** since we cannot cast the block entity to this **RenderBlockTileEntity** class.

I just wanted it to not crash at the very least. If you have any better fix, please let me know.