### PR TITLE
Make upgrade not poof on mod update

### DIFF
--- a/src/main/java/com/direwolf20/mininggadgets/common/items/MiningGadget.java
+++ b/src/main/java/com/direwolf20/mininggadgets/common/items/MiningGadget.java
@@ -56,6 +56,7 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.event.level.BlockEvent;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -78,6 +79,18 @@ public class MiningGadget extends Item {
     }
 
     //TODO Add an override for onCreated and initialize all NBT Tags in it
+
+    @Override
+    public void verifyTagAfterLoad(@NotNull CompoundTag tag) {
+        if (UpgradeTools.containsUpgrades(tag)) {
+            UpgradeTools.walkUpgradesOnTag(tag, (CompoundTag upgradeTag, String upgradeName) -> {
+                if (upgradeName.equalsIgnoreCase("three_by_three")) {
+                    return Upgrade.SIZE_1.getName();
+                }
+                return null;
+            });
+        }
+    }
 
     @Override
     public int getMaxDamage(ItemStack stack) {
@@ -414,7 +427,7 @@ public class MiningGadget extends Item {
                 efficiency = UpgradeTools.getUpgradeFromGadget((stack), Upgrade.EFFICIENCY_1).get().getTier();
 
             float hardness = getHardness(coords, (Player) player, efficiency);
-            hardness = hardness * MiningProperties.getRange(stack) * 1;
+            // hardness = hardness * MiningProperties.getRange(stack) * 1;
             hardness = (float) Math.floor(hardness);
             if (hardness == 0) hardness = 1;
             for (BlockPos coord : coords) {

--- a/src/main/java/com/direwolf20/mininggadgets/common/items/upgrade/UpgradeTools.java
+++ b/src/main/java/com/direwolf20/mininggadgets/common/items/upgrade/UpgradeTools.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 public class UpgradeTools {
@@ -120,6 +121,23 @@ public class UpgradeTools {
         return functionalUpgrades;
     }
 
+    public static void walkUpgradesOnTag(CompoundTag tagCompound, BiFunction<CompoundTag, String, String> consumer) {
+        ListTag upgrades = tagCompound.getList(KEY_UPGRADES, Tag.TAG_COMPOUND);
+
+        if (upgrades.isEmpty())
+            return;
+
+        for (int i = 0; i < upgrades.size(); i++) {
+            CompoundTag tag = upgrades.getCompound(i);
+
+            var name = tag.getString(KEY_UPGRADE);
+            var result = consumer.apply(tag, name);
+            if (result != null && !result.equalsIgnoreCase(name)) {
+                tag.putString(KEY_UPGRADE, result);
+            }
+        }
+    }
+
     @Nullable
     public static Upgrade getUpgradeByName(String name) {
         // If the name doesn't exist then move on
@@ -144,6 +162,9 @@ public class UpgradeTools {
 
     public static boolean containsUpgrades(ItemStack tool) {
         return tool.getOrCreateTag().contains(KEY_UPGRADES);
+    }
+    public static boolean containsUpgrades(CompoundTag tag) {
+        return tag.contains(KEY_UPGRADES);
     }
 
     /**


### PR DESCRIPTION
When i updated the mod, any existing `three_by_three` upgrades poofed. because we renamed it to a tiered upgrade `size_1`

This code does a migration when the item is deserialized by the server, and "renames" `three_by_three` to `size_1` threrby not making the upgrade poof .. or having multiple upgrades pop up (ask me how i know ... )