### PR TITLE
Stop converting chests to ice

### DIFF
--- a/src/main/java/com/direwolf20/mininggadgets/common/tiles/RenderBlockTileEntity.java
+++ b/src/main/java/com/direwolf20/mininggadgets/common/tiles/RenderBlockTileEntity.java
@@ -222,7 +222,8 @@ public class RenderBlockTileEntity extends BlockEntity {
 
         // If the block is just water logged, remove the fluid
         BlockState blockState = world.getBlockState(pos);
-        if (blockState.hasProperty(BlockStateProperties.WATERLOGGED) && blockState.getValue(BlockStateProperties.WATERLOGGED) && world.getBlockEntity(pos) == null) {
+        // Chests have a tile entity, and are then converted to ice below, we need them to lose waterlogged
+        if (blockState.hasProperty(BlockStateProperties.WATERLOGGED) && blockState.getValue(BlockStateProperties.WATERLOGGED)) {
             world.setBlockAndUpdate(pos, blockState.setValue(BlockStateProperties.WATERLOGGED, false));
             return costOfOperation;
         }


### PR DESCRIPTION
Fixes #233 

Blocks with a tile entity are considered a Source block, and are converted (forcefully) into blocks of ice deleting them.

I can't see why the check for a block entity was done here, unless it was something to do with not touching block entities?
