### PR TITLE
Use block outline for ray tracing

### DIFF
--- a/src/main/java/com/direwolf20/mininggadgets/common/util/VectorHelper.java
+++ b/src/main/java/com/direwolf20/mininggadgets/common/util/VectorHelper.java
@@ -23,7 +23,7 @@ public class VectorHelper {
         Vec3 start = new Vec3(player.getX(), player.getY() + player.getEyeHeight(), player.getZ());
 
         Vec3 end = new Vec3(player.getX() + look.x * (double) range, player.getY() + player.getEyeHeight() + look.y * (double) range, player.getZ() + look.z * (double) range);
-        ClipContext context = new ClipContext(start, end, ClipContext.Block.COLLIDER, rayTraceFluid, player);
+        ClipContext context = new ClipContext(start, end, ClipContext.Block.OUTLINE, rayTraceFluid, player);
         return world.clip(context);
     }
 }


### PR DESCRIPTION
This resolves the issue where blocks without collisions aren't minable with the laser. Now blocks like tall grass, powered snow, flowers, etc., are minable